### PR TITLE
PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ language: php
 
 sudo: false
 
-php:
-  - 7
-  - 7.1
-  - 7.2
-  - nightly
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
 
-env: TMPDIR=/tmp USE_XDEBUG=false
+env:
+  global:
+    - COMPOSER_ARGS="" TMPDIR=/tmp USE_XDEBUG=false
 
 branches:
   only:
@@ -16,7 +17,7 @@ branches:
 
 install:
   - phpenv rehash
-  - travis_retry composer install --no-interaction --prefer-source
+  - travis_retry composer update --no-interaction --prefer-source $COMPOSER_ARGS
 
 stages:
   - test
@@ -35,18 +36,34 @@ jobs:
   allow_failures:
     - php: nightly
   include:
+    - php: 7
+      env: COMPOSER_ARGS="--prefer-lowest"
+    - php: 7
+    - php: 7.1
+      env: COMPOSER_ARGS="--prefer-lowest"
+    - php: 7.1
+    - php: 7.2
+      env: COMPOSER_ARGS="--prefer-lowest"
+    - php: 7.2
+    - php: nightly
+      env: COMPOSER_ARGS="--ignore-platform-reqs --prefer-lowest"
+    - php: nightly
+      env: COMPOSER_ARGS="--ignore-platform-reqs"
+
     - stage: style check
-      php: 7.1
+      php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=false
       script:
         - composer style-check
+
     - stage: phpstan analysis
-      php: 7.1
+      php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=false
       script:
         - composer phpstan
+
     - stage: test with coverage
-      php: 7.1
+      php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=true CC_TEST_REPORTER_ID=8cbcfb40a4aff9431a0600f0a0ccb25ef4379d427443da50358d10f04a65f35f
       before_script:
         - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter

--- a/src/Zend/View/Helper/HeadLink.php
+++ b/src/Zend/View/Helper/HeadLink.php
@@ -365,6 +365,7 @@ class Zend_View_Helper_HeadLink extends Zend_View_Helper_Placeholder_Container_S
         $media                 = 'screen';
         $conditionalStylesheet = false;
         $href                  = array_shift($args);
+        $extras                = array();
 
         if ($this->_isDuplicateStylesheet($href)) {
             return false;
@@ -426,10 +427,11 @@ class Zend_View_Helper_HeadLink extends Zend_View_Helper_Placeholder_Container_S
             throw $e;
         }
 
-        $rel   = 'alternate';
-        $href  = array_shift($args);
-        $type  = array_shift($args);
-        $title = array_shift($args);
+        $rel    = 'alternate';
+        $href   = array_shift($args);
+        $type   = array_shift($args);
+        $title  = array_shift($args);
+        $extras = array();
 
         if (0 < count($args) && is_array($args[0])) {
             $extras = array_shift($args);


### PR DESCRIPTION
Noticed some tests were failing on travis.

Going to get these to run on php 7.3, then fix errors (seems to be a case where `compact` throws a notice on undefined variables in php 7.3, but didn't before).