### PR TITLE
Fix PHPDoc layout() method

### DIFF
--- a/src/Zend/View.php
+++ b/src/Zend/View.php
@@ -65,7 +65,7 @@
  * @method string htmlQuicktime($data, array $attribs = array(), array $params = array(), $content = null)
  * @method Zend_View_Helper_InlineScript inlineScript($mode = Zend_View_Helper_HeadScript::FILE, $spec = null, $placement = 'APPEND', array $attrs = array(), $type = 'text/javascript')
  * @method string|void json($data, $keepLayouts = false, $encodeData = true)
- * @method Zend_View_Helper_Layout layout()
+ * @method Zend_Layout layout()
  * @method Zend_View_Helper_Navigation navigation(Zend_Navigation_Container $container = null)
  * @method string paginationControl(Zend_Paginator $paginator = null, $scrollingStyle = null, $partial = null, $params = null)
  * @method string partial($name = null, $module = null, $model = null)


### PR DESCRIPTION
Zend_View_Helper_Layout::layout() returns Zend_Layout directly instead of itself.